### PR TITLE
changing H3 to H2

### DIFF
--- a/pmpro-address-for-free-levels.php
+++ b/pmpro-address-for-free-levels.php
@@ -47,7 +47,7 @@ function pmproaffl_pmpro_checkout_boxes_require_address() {
                 {
                 ?>
                     //change heading
-                   jQuery('#pmpro_billing_address_fields .pmpro_checkout-h3-name').html('<?php esc_html_e("Address", "pmpro-address-for-free-levels");?>');               
+                   jQuery('#pmpro_billing_address_fields .pmpro_checkout-h2-name').html('<?php esc_html_e("Address", "pmpro-address-for-free-levels");?>');               
                                <?php
                 }
             ?>


### PR DESCRIPTION
Changed the class in jQuery to h2 for update.

PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.