### PR TITLE
Require billing fields for free levels.

### DIFF
--- a/pmpro-address-for-free-levels.php
+++ b/pmpro-address-for-free-levels.php
@@ -221,12 +221,16 @@ function pmproaffl_required_billing_fields_for_free_level( $okay ) {
 	}
 
 	// Make sure all billing fields are filled out.
+	$missing_required_field = false;
 	foreach ( $pmpro_required_billing_fields as $field => $value ) {
-		if ( ! isset( $_REQUEST[ $field ] ) || '' === trim( $_REQUEST[ $field ] ) ) {
+		if ( empty( $_REQUEST[ $field ] ) ) {
 			$pmpro_error_fields[] = $field;
-			pmpro_setMessage( __( 'Please complete all required fields.', 'pmpro-address-for-free-levels' ), 'pmpro_error' );
+			$missing_required_field = true;
 			$okay = false;
 		}
+	}
+	if ( $missing_required_field ) {
+		pmpro_setMessage( __( 'Please complete all required fields.', 'pmpro-address-for-free-levels' ), 'pmpro_error' );
 	}
 
 	return $okay;

--- a/pmpro-address-for-free-levels.php
+++ b/pmpro-address-for-free-levels.php
@@ -222,7 +222,7 @@ function pmproaffl_required_billing_fields_for_free_level( $okay ) {
 
 	// Make sure all billing fields are filled out.
 	foreach ( $pmpro_required_billing_fields as $field => $value ) {
-		if ( empty( $_REQUEST[ $field ] ) ) {
+		if ( ! isset( $_REQUEST[ $field ] ) || '' === trim( $_REQUEST[ $field ] ) ) {
 			$pmpro_error_fields[] = $field;
 			pmpro_setMessage( __( 'Please complete all required fields.', 'pmpro-address-for-free-levels' ), 'pmpro_error' );
 			$okay = false;

--- a/pmpro-address-for-free-levels.php
+++ b/pmpro-address-for-free-levels.php
@@ -200,6 +200,40 @@ function pmproaffl_pmpro_checkout_order_free($morder) {
 add_filter( 'pmpro_checkout_order_free', 'pmproaffl_pmpro_checkout_order_free' );
 
 /**
+ * Enforce required billing fields for free checkouts.
+ *
+ * @since TBD
+ * 
+ * @param boolean $okay Whether previous checks passed.
+ * @return boolean $okay Whether all checks passed.
+ */
+function pmproaffl_required_billing_fields_for_free_level( $okay ) {
+	global $pmpro_error_fields, $pmpro_required_billing_fields;
+
+	// If something else is wrong, let's not proceed.
+	if ( ! $okay ) {
+		return $okay;
+	}
+
+	// Let core handle this for paid levels.
+	if ( ! pmpro_isLevelFree( pmpro_getLevelAtCheckout() ) ) {
+		return $okay;
+	}
+
+	// Make sure all billing fields are filled out.
+	foreach ( $pmpro_required_billing_fields as $field => $value ) {
+		if ( empty( $_REQUEST[ $field ] ) ) {
+			$pmpro_error_fields[] = $field;
+			pmpro_setMessage( __( 'Please complete all required fields.', 'pmpro-address-for-free-levels' ), 'pmpro_error' );
+			$okay = false;
+		}
+	}
+
+	return $okay;
+}
+add_filter( 'pmpro_checkout_order_creation_checks', 'pmproaffl_required_billing_fields_for_free_level', 20 );
+
+/**
  * After checkout, clear any session vars.
  */
 function pmproaffl_pmpro_after_checkout() {

--- a/pmpro-address-for-free-levels.php
+++ b/pmpro-address-for-free-levels.php
@@ -202,7 +202,7 @@ add_filter( 'pmpro_checkout_order_free', 'pmproaffl_pmpro_checkout_order_free' )
 /**
  * Enforce required billing fields for free checkouts.
  *
- * @since TBD
+ * @since 0.6
  * 
  * @param boolean $okay Whether previous checks passed.
  * @return boolean $okay Whether all checks passed.


### PR DESCRIPTION
* BUG FIX: Fixed an issue where required fields were skippable for free checkouts.

Resolves: https://github.com/strangerstudios/pmpro-address-for-free-levels/issues/9

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-address-for-free-levels/pulls) for the same update/change?