### PR TITLE
FIX: PHP notice on frontend

### DIFF
--- a/pmpro-address-for-free-levels.php
+++ b/pmpro-address-for-free-levels.php
@@ -216,7 +216,8 @@ function pmproaffl_required_billing_fields_for_free_level( $okay ) {
 	}
 
 	// Let core handle this for paid levels.
-	if ( ! pmpro_isLevelFree( pmpro_getLevelAtCheckout() ) ) {
+    $level = pmpro_getLevelAtCheckout();
+	if ( ! pmpro_isLevelFree( $level ) ) {
 		return $okay;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-address-for-free-levels/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request updates the way the membership level is passed to `pmpro_isLevelFree()` by assigning the return value of `pmpro_getLevelAtCheckout()` to a variable first.

Previously, the function call was passed directly, which caused the PHP notice:

> Notice: Only variables should be passed by reference

By storing the level in a variable before passing it to `pmpro_isLevelFree()`, the notice is resolved while preserving the existing functionality.

### How to test the changes in this Pull Request:

1. Enable the **PMPro Address for Free Levels** plugin.
2. Go to checkout with both a free membership level and a paid membership level.
3. Confirm that no PHP notices are triggered and that the behavior remains unchanged for free vs paid levels.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
> Fixed a PHP notice by ensuring the membership level is assigned to a variable before being passed by reference to `pmpro_isLevelFree()`.
