### PR TITLE
Fix free checkout by not requiring CVV (support post 682669)

### DIFF
--- a/pmpro-address-for-free-levels.php
+++ b/pmpro-address-for-free-levels.php
@@ -221,10 +221,11 @@ function pmproaffl_required_billing_fields_for_free_level( $okay ) {
 		return $okay;
 	}
 
-	// Unset the default billing fields: AccountNumber, ExpirationMonth, ExpirationYear
+	// Unset the default billing fields: AccountNumber, ExpirationMonth, ExpirationYear, CVV
 	unset( $pmpro_required_billing_fields['AccountNumber'] );
 	unset( $pmpro_required_billing_fields['ExpirationMonth'] );
 	unset( $pmpro_required_billing_fields['ExpirationYear'] );
+	unset( $pmpro_required_billing_fields['CVV'] );
 
 	// Make sure all billing fields are filled out.
 	$missing_required_field = false;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-address-for-free-levels/pulls) for the same update/change?


### Changes proposed in this Pull Request:

After release 0.6, membership checkout would no longer work for free membership levels due to a "Please complete all required fields" error. This issue remained for me even after upgrading to 0.6.1, where it was indicated the bug was fixed.

Local testing indicated that not un-setting the required CVV field in function pmproaffl_required_billing_fields_for_free_level, like with AccountNumber, ExpirationMonth, and ExpirationYear, was likely the cause of the issue. I was able to once again submit the free membership checkout form after this change.

### How to test the changes in this Pull Request:

1. Navigate to the membership-checkout page as a guest and choose a free membership level.
2. Fill out all required address fields as indicated by a * and click Submit and Confirm.
3. Form should successfully submit.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry
>Updated logic in pmproaffl_required_billing_fields_for_free_level function to not require CVV for free checkouts.